### PR TITLE
Abstract commands

### DIFF
--- a/src/main/java/net/cyberkitsune/prefixchat/ChatListener.java
+++ b/src/main/java/net/cyberkitsune/prefixchat/ChatListener.java
@@ -112,6 +112,7 @@ public class ChatListener implements Listener {
 				for (Player p : target_channel.getRecipients(message, evt))
 					p.sendMessage(message);
 				evt.setCancelled(true);
+				KitsuneChat.getInstance().mcLog.info(message); // Log to console for admin review (consider moving logic into postMessage?)
 			} else {
 				// Send in a vanilla way, so we can pass the message to other plugins.
 				evt.setFormat(message.replace("%", "%%"));   // Not sure why, old KC had the replace.

--- a/src/main/java/net/cyberkitsune/prefixchat/ConnectHandler.java
+++ b/src/main/java/net/cyberkitsune/prefixchat/ConnectHandler.java
@@ -35,7 +35,7 @@ public class ConnectHandler implements Listener {
 			KitsuneChannel channel = KitsuneChat.getInstance().getChannelByPrefix(currentChannel);
 			if (channel != null)
 			{
-				evt.getPlayer().sendMessage(ChatColor.GRAY+String.format("[KitsuneChat] Current talking in: %s. Run /kc %s to return to default.",
+				evt.getPlayer().sendMessage(ChatColor.GRAY+String.format("[KitsuneChat] Current talking to %s. Run /kc %s to return to default.",
 						channel.getChannelName(), KitsuneChat.getInstance().getConfig().getString("channels.default")));
 
 			}

--- a/src/main/java/net/cyberkitsune/prefixchat/ConnectHandler.java
+++ b/src/main/java/net/cyberkitsune/prefixchat/ConnectHandler.java
@@ -1,5 +1,7 @@
 package net.cyberkitsune.prefixchat;
 
+import net.cyberkitsune.prefixchat.channels.KitsuneChannel;
+import org.bukkit.ChatColor;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
@@ -21,8 +23,22 @@ public class ConnectHandler implements Listener {
 		if(!KitsuneChatUserData.getInstance().getPartyDataForUser(evt.getPlayer()).equalsIgnoreCase(""))  {
 			ChatParties.getInstance().changeParty(evt.getPlayer(), KitsuneChatUserData.getInstance().getPartyDataForUser(evt.getPlayer()));
 		}
+
 		if(KitsuneChatUserData.getInstance().getUserChannel(evt.getPlayer()) == null) {
 			KitsuneChatUserData.getInstance().setUserChannel(evt.getPlayer(), KitsuneChat.getInstance().getConfig().getString("channels.default"));
+		}
+
+		// A friendly reminder....
+		String currentChannel = KitsuneChatUserData.getInstance().getUserChannel(evt.getPlayer());
+		if(!currentChannel.equals(KitsuneChat.getInstance().getConfig().getString("channels.default")))
+		{
+			KitsuneChannel channel = KitsuneChat.getInstance().getChannelByPrefix(currentChannel);
+			if (channel != null)
+			{
+				evt.getPlayer().sendMessage(ChatColor.GRAY+String.format("[KitsuneChat] Current talking in: %s. Run /kc %s to return to default.",
+						channel.getChannelName(), KitsuneChat.getInstance().getConfig().getString("channels.default")));
+
+			}
 		}
 	}
 

--- a/src/main/java/net/cyberkitsune/prefixchat/KitsuneChat.java
+++ b/src/main/java/net/cyberkitsune/prefixchat/KitsuneChat.java
@@ -6,6 +6,7 @@ import java.util.*;
 import java.util.logging.Logger;
 
 import net.cyberkitsune.prefixchat.channels.KitsuneChannel;
+import net.cyberkitsune.prefixchat.command.KCommand;
 import net.milkbowl.vault.chat.Chat;
 
 import org.bukkit.command.PluginCommand;
@@ -23,6 +24,7 @@ public class KitsuneChat extends JavaPlugin {
 
 	private static KitsuneChat instance = null;
 	public HashMap<String, KitsuneChannel> channels;
+	public HashMap<String, KCommand> commands;
 	public Logger mcLog = Logger.getLogger("Minecraft");
 	public KitsuneChatCommand exec = new KitsuneChatCommand();
 	public UserMessaging msgExec = new UserMessaging();
@@ -221,6 +223,26 @@ public class KitsuneChat extends JavaPlugin {
 		if (!channels.containsKey(defaultChannel))
 			mcLog.warning("[KitsuneChat] Your set default channel does not exist or is not enabled. Make sure to " +
 					"fix this in the config.yml");
+	}
+
+	private void loadCommands()
+	{
+		commands.clear();
+		// Reflect through all the commands, including aliases
+		Reflections reflections = new Reflections("net.cyberkitsune.prefixchat.command");
+		for(Class<? extends KCommand> cmdClass : reflections.getSubTypesOf(KCommand.class))
+		{
+			try {
+				KCommand kc = cmdClass.getDeclaredConstructor().newInstance();
+				commands.put(kc.getName(), kc);
+				for (String alias : kc.getAliases())
+				{
+					commands.put(alias, kc);
+				}
+			} catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+				e.printStackTrace();
+			}
+		}
 	}
 
 	public KitsuneChannel getChannelByPrefix(String prefix)

--- a/src/main/java/net/cyberkitsune/prefixchat/KitsuneChat.java
+++ b/src/main/java/net/cyberkitsune/prefixchat/KitsuneChat.java
@@ -223,4 +223,14 @@ public class KitsuneChat extends JavaPlugin {
 					"fix this in the config.yml");
 	}
 
+	public KitsuneChannel getChannelByPrefix(String prefix)
+	{
+		if (channels.containsKey(prefix))
+		{
+			return channels.get(prefix);
+		}
+
+		return null;
+	}
+
 }

--- a/src/main/java/net/cyberkitsune/prefixchat/KitsuneChatCommand.java
+++ b/src/main/java/net/cyberkitsune/prefixchat/KitsuneChatCommand.java
@@ -160,6 +160,7 @@ public class KitsuneChatCommand implements CommandExecutor, TabCompleter {
 				case 1:
 					// No command specificed, or partial command.
 					possibleCompletions.addAll(getCommandNamesForSender(commandSender));
+					possibleCompletions.add("?");
 					break;
 				case 2:
 				default:

--- a/src/main/java/net/cyberkitsune/prefixchat/KitsuneChatCommand.java
+++ b/src/main/java/net/cyberkitsune/prefixchat/KitsuneChatCommand.java
@@ -1,6 +1,7 @@
 package net.cyberkitsune.prefixchat;
 
 import net.cyberkitsune.prefixchat.channels.KitsuneChannel;
+import net.cyberkitsune.prefixchat.command.KCommand;
 import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.ComponentBuilder;
 import net.md_5.bungee.api.chat.HoverEvent;
@@ -9,161 +10,186 @@ import org.bukkit.ChatColor;
 import org.bukkit.command.*;
 import org.bukkit.entity.Player;
 import org.bukkit.util.StringUtil;
+import org.jetbrains.annotations.NotNull;
+import org.reflections.Reflections;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.*;
 
 public class KitsuneChatCommand implements CommandExecutor, TabCompleter {
-	
-	public KitsuneChatCommand() {}
 
-	public boolean onCommand(CommandSender sender, Command command,
-							 String label, String[] args) {
+
+	private HashMap<String, KCommand> commands;
+	public KitsuneChatCommand()
+	{
+		commands = new HashMap<>();
+		loadCommands();
+	}
+
+	private void loadCommands()
+	{
+		commands.clear();
+		// Reflect through all the commands, including aliases
+		Reflections reflections = new Reflections("net.cyberkitsune.prefixchat.command");
+		for(Class<? extends KCommand> cmdClass : reflections.getSubTypesOf(KCommand.class))
+		{
+			try {
+				KCommand kc = cmdClass.getDeclaredConstructor().newInstance();
+				if(!kc.getName().equals("?"))
+					commands.put(kc.getName(), kc);
+				for (String alias : kc.getAliases())
+				{
+					if(!alias.equals("?"))
+						commands.put(alias, kc);
+				}
+			} catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+				e.printStackTrace();
+			}
+		}
+	}
+
+	public boolean onCommand(@NotNull CommandSender sender, Command command,
+							 @NotNull String label, @NotNull String[] args) {
 		if (command.getName().equalsIgnoreCase("kc")) {
-			if (args.length > 0) {
-				if (args[0].equalsIgnoreCase("reload")) {
-					if (sender instanceof ConsoleCommandSender || sender.hasPermission("kitsunechat.reload")) {
-						KitsuneChat.getInstance().reload();
-						sender.sendMessage(ChatColor.GRAY + "[KitsuneChat] KitsuneChat reloaded! >w<");
-					} else {
-						sender.sendMessage(ChatColor.RED + "[KitsuneChat] You do not have permission to reload.");
-					}
+			// Step one, check if a command was not requested, or if help was requested specifically.
+			if (args.length < 1)
+			{
+				sender.sendMessage(ChatColor.RED + "[KitsuneChat] No command specified. Possible commands:");
+				printHelp(sender);
+			}
+			else if (args[0].equals("?"))
+			{
+				sender.sendMessage(ChatColor.YELLOW+"[KitsuneChat] KitsuneChat - Channeled Chat System v"+KitsuneChat.getInstance().getDescription().getVersion()+" by CyberKitsune.");
+				printHelp(sender);
+			}
+			else if (!commands.containsKey(args[0]))
+			{
+				sender.sendMessage(ChatColor.RED + "[KitsuneChat] Invalid command specified. Possible commands:");
+				printHelp(sender);
+			}
+			else
+			{
+				KCommand cmd = commands.get(args[0]);
+
+				String subCommand = null;
+				String[] subCommandArgs = {};
+				if(args.length > 2)
+					subCommand = args[1];
+
+				if(args.length > 3)
+					subCommandArgs = Arrays.copyOfRange(args, 2, args.length);
+
+				if(cmd.requiresPlayer() && !(sender instanceof Player))
+				{
+					sender.sendMessage(ChatColor.RED + "[KitsuneChat] This command must be run by a player.");
 					return true;
 				}
-				if (sender instanceof Player) {
-					if (args[0].equalsIgnoreCase("party") || args[0].equalsIgnoreCase("p")) {
-						if (args.length > 1) {
-							if (args[1].equalsIgnoreCase("leave")) {
-								ChatParties.getInstance().leaveParty((Player) sender, false);
-								return true;
-							} else if (args[1].equalsIgnoreCase("list")) {
-								if (ChatParties.getInstance().isInAParty((Player) sender)) {
-									StringBuilder playerlist = new StringBuilder();
-									int playerCount = 0;
-									for (Player plr : ChatParties.getInstance().getPartyMembers(ChatParties.getInstance().getPartyName((Player) sender))) {
-										playerlist.append(plr.getDisplayName()).append(", ");
-										playerCount++;
-									}
-									playerlist = new StringBuilder(playerlist.substring(0, playerlist.length() - 2) + ".");
-									sender.sendMessage(ChatColor.YELLOW + "[KitsuneChat] " + playerCount + ((playerCount == 1) ? " person " : " people ") + "in the party.");
-									sender.sendMessage(ChatColor.YELLOW + "[KitsuneChat] They are: " + playerlist + ".");
-									return true;
-								} else {
-									sender.sendMessage(ChatColor.RED + "[KitsuneChat] You are not in a party!");
-									return true;
-								}
-							} else if (args[1].equalsIgnoreCase("join")) {
-								if (args.length < 3) {
-									sender.sendMessage(ChatColor.RED + "[KitsuneChat] Usage: /kc party join <party_name>");
-									return true;
-								}
-								ChatParties.getInstance().changeParty((Player) sender, args[2].toLowerCase());
-								KitsuneChatUserData.getInstance().setUserChannel((Player) sender, KitsuneChat.getInstance().getConfig().getString("channels.party.prefix"));
-								sender.sendMessage(ChatColor.YELLOW + "[KitsuneChat] You have joined the party " + args[2].toLowerCase() + "!");
-							} else if (args[1].equalsIgnoreCase("invite")) {
-								if (args.length > 2) {
-									if (ChatParties.getInstance().isInAParty((Player) sender)) {
-										Player target = KitsuneChat.getInstance().getServer().getPlayer(args[2]);
-										if (target != null) {
-											ComponentBuilder cb = new ComponentBuilder("[KitsuneChat] ").
-													color(net.md_5.bungee.api.ChatColor.YELLOW).append(sender.getName())
-													.color(net.md_5.bungee.api.ChatColor.YELLOW).append(" has invited you to a party! Click here to join: ")
-													.color(net.md_5.bungee.api.ChatColor.YELLOW).append("[ACCEPT]")
-													.color(net.md_5.bungee.api.ChatColor.GREEN).bold(true).event(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/kc party join " + ChatParties.getInstance().getPartyName((Player) sender)))
-													.event(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new ComponentBuilder("Click to join " + ChatParties.getInstance().getPartyName((Player) sender)).create()));
-											target.spigot().sendMessage(cb.create());
-											ChatParties.getInstance().notifyParty(ChatParties.getInstance().getPartyName((Player) sender), ChatColor.GREEN + "[KitsuneChat] " + sender.getName() + " invited " + target.getDisplayName() + ChatColor.GREEN + " to the party.");
-										} else {
-											sender.sendMessage(ChatColor.RED + "[KitsuneChat] That player does not exist!");
-										}
-									} else {
-										sender.sendMessage(ChatColor.RED + "[KitsuneChat] You aren't in a party!");
-									}
-								} else {
-									sender.sendMessage(ChatColor.RED + "[KitsuneChat] You didn't specify a player!");
-								}
-							} else {
-								sender.sendMessage(ChatColor.RED + "[KitsuneChat] Usage: /kc party (join|leave|invite|list)");
-							}
-						} else {
-							sender.sendMessage(ChatColor.RED + "[KitsuneChat] Usage: /kc party (join|leave|invite|list)");
-						}
-					} else if (args[0].equalsIgnoreCase("?")) {
-						printHelp((Player) sender);
-					} else if (args[0].equalsIgnoreCase("null")) { // Dummy command for the /me full stop.
-						return true;
-					} else {
-						for (KitsuneChannel channel : KitsuneChat.getInstance().channels.values()) {
-							if (args[0].equalsIgnoreCase(channel.getPrefix())) {
-								if (!channel.hasPermission((Player) sender)) {
-									sender.sendMessage(ChatColor.RED + "[KitsuneChat] You do not have permission to use the " + channel.getChannelName() + " channel.");
-									return true;
-								}
-								KitsuneChatUserData.getInstance().setUserChannel((Player) sender, channel.getPrefix());
-								sender.sendMessage(ChatColor.YELLOW + "[KitsuneChat] Default chat now set to " + channel.getChannelName());
-								return true;
-							}
-						}
-						sender.sendMessage(ChatColor.RED + "[KitsuneChat] Unknown or missing command. See /kc ? for help.");
-					}
+
+				// We're a player, so we should do a permission check
+				if(sender instanceof Player && !cmd.hasPermission((Player) sender, subCommand))
+				{
+					sender.sendMessage(ChatColor.RED + "[KitsuneChat] You do not have permission to do that.");
+					return true;
 				}
-			}
-			else {
-				sender.sendMessage(ChatColor.RED + "[KitsuneChat] Unknown or missing command. See /kc ? for help.");
+
+				// OK we have perms, have collected arguments, now we run the command.
+				boolean argsValid = cmd.runCommand(sender, subCommand, subCommandArgs);
+				if(!argsValid)
+				{
+					sender.sendMessage(ChatColor.RED + String.format("[KitsuneChat] Invalid usage of /kc %s. Possible usages:", cmd.getName()));
+					for(String sCmd : cmd.getSubCommands())
+						sender.sendMessage(ChatColor.YELLOW + "[KitsuneChat]" + cmd.getHelpForSubcommand(sCmd));
+				}
+
+
 			}
 			return true;
 		} else return !command.getName().equalsIgnoreCase("me");
 	}
 	
-	public void printHelp(Player target) {
-		target.sendMessage(ChatColor.YELLOW+"[KitsuneChat] KitsuneChat - Channeled Chat System v"+KitsuneChat.getInstance().getDescription().getVersion()+" by CyberKitsune.");
+	private void printHelp(CommandSender target) {
 		target.sendMessage(ChatColor.YELLOW+"[KitsuneChat] /kc ? - Help, this command. ");
-		target.sendMessage(ChatColor.YELLOW+"[KitsuneChat] /kc party join <name> - Join a party with name <name>. ");
-		target.sendMessage(ChatColor.YELLOW+"[KitsuneChat] /kc party list - Lists who is in your party.");
-		target.sendMessage(ChatColor.YELLOW+"[KitsuneChat] /kc party leave - Leaves your current party. ");
-		target.sendMessage(ChatColor.YELLOW+"[KitsuneChat] /kc party invite <player> - Invites <player> to your current party.");
-		for(KitsuneChannel channel : KitsuneChat.getInstance().channels.values()) {
-			if (channel.hasPermission(target))
-				target.sendMessage(ChatColor.YELLOW+"[KitsuneChat] /kc "+channel.getPrefix()+" - Change default channel to "+channel.getChannelName()+".");
+		ArrayList<String> checkedCommands = new ArrayList<>();
+		for (KCommand cmd : commands.values())
+		{
+			if (checkedCommands.contains(cmd.getName()))
+				continue;
+
+			checkedCommands.add(cmd.getName());
+			if(!cmd.senderCanRunCommand(target, null))
+				continue;
+
+			StringBuilder sb = new StringBuilder(ChatColor.YELLOW.toString());
+			sb.append("[KitsuneChat] /kc ").append(cmd.getName());
+			if(cmd.getAliases().size() > 0)
+			{
+				sb.append("(or: ");
+				sb.append(String.join(",", cmd.getAliases()));
+				sb.append(") ");
+			}
+			sb.append("- ").append(cmd.getHelp());
+			target.sendMessage(sb.toString());
 		}
-		if (target.hasPermission("kitsunechat.reload"))
-			target.sendMessage("[KitsuneChat] /kc reload - Reload KitsuneChat");
+	}
+
+	private List<String> getCommandNamesForSender(CommandSender s)
+	{
+		ArrayList<String> names = new ArrayList<>();
+		for(Map.Entry<String, KCommand> cmdEntry : commands.entrySet())
+		{
+			KCommand cmd = cmdEntry.getValue();
+
+			if(cmd.senderCanRunCommand(s, null))
+				names.add(cmdEntry.getKey());
+		}
+		return names;
 	}
 
 	@Override
-	public List<String> onTabComplete(CommandSender commandSender, Command command, String s, String[] strings) {
+	public List<String> onTabComplete(CommandSender commandSender, Command command, String alias, String[] args) {
 		if (command.getName().equalsIgnoreCase("kc"))
 		{
-			ArrayList<String> possibleCompletions = new ArrayList<>(Arrays.asList("?", "party"));
-			if(commandSender.hasPermission("kitsunechat.reload"))
-				possibleCompletions.add("reload");
-			possibleCompletions.addAll(KitsuneChat.getInstance().channels.keySet());
-
-			final List<String> completions = new ArrayList<>();
-			int checkIndex = 0;
-			if(strings[0].equals("party"))
+			ArrayList<String> possibleCompletions = new ArrayList<>();
+			switch (args.length)
 			{
-				possibleCompletions = new ArrayList<>(Arrays.asList("join", "list", "leave", "invite"));
-				if(strings.length > 1)
-				{
-					checkIndex = 1;
-					switch (strings[1]) {
-						case "join":
-							return Collections.singletonList("<party_name>");
-						case "invite":
-							return null;
-						case "leave":
-						case "list":
-							return Collections.singletonList("");
+				case 0:
+				case 1:
+					// No command specificed, or partial command.
+					possibleCompletions.addAll(getCommandNamesForSender(commandSender));
+					break;
+				case 2:
+				default:
+					// Command specified. Use handler.
+					if(commands.containsKey(args[0]))
+					{
+						KCommand cmd = commands.get(args[0]);
+						String subCommand = null;
+						String[] subCommandArgs = {};
+
+						if(args.length > 3)
+							subCommand = args[1];
+							subCommandArgs = Arrays.copyOfRange(args, 2, args.length);
+						if(cmd.senderCanRunCommand(commandSender, subCommand))
+						{
+							List<String> cmdCompletions = cmd.getPossibleCompletions(commandSender, subCommand);
+							if(cmdCompletions == null)
+								return null;
+							else if(cmdCompletions.isEmpty())
+								return cmdCompletions;
+							else
+								possibleCompletions.addAll(cmdCompletions);
+						}
+
 					}
-				}
-
-			} else if(strings.length > 1)
-			{
-				possibleCompletions = new ArrayList<>();
+					else
+					{
+						return Collections.emptyList();
+					}
 			}
 
+			final List<String> completions = new ArrayList<>();
 
-			StringUtil.copyPartialMatches(strings[checkIndex], possibleCompletions, completions);
+			StringUtil.copyPartialMatches(args[args.length - 1], possibleCompletions, completions);
 
 			Collections.sort(completions);
 
@@ -171,11 +197,11 @@ public class KitsuneChatCommand implements CommandExecutor, TabCompleter {
 		}
 		else if(command.getName().equalsIgnoreCase("me"))
 		{
-			return Collections.singletonList("");
+			return Collections.emptyList();
 		}
 		else if(command.getName().equalsIgnoreCase("r"))
 		{
-			return Collections.singletonList("<reply>");
+			return Collections.emptyList();
 		}
 
 		return null;

--- a/src/main/java/net/cyberkitsune/prefixchat/KitsuneChatCommand.java
+++ b/src/main/java/net/cyberkitsune/prefixchat/KitsuneChatCommand.java
@@ -98,7 +98,11 @@ public class KitsuneChatCommand implements CommandExecutor, TabCompleter {
 				{
 					sender.sendMessage(ChatColor.RED + String.format("[KitsuneChat] Invalid usage of /kc %s. Possible usages:", cmd.getName()));
 					for(String sCmd : cmd.getSubCommands())
-						sender.sendMessage(ChatColor.YELLOW + "[KitsuneChat] " + cmd.getHelpForSubcommand(sCmd));
+					{
+						if(cmd.senderCanRunCommand(sender, sCmd))
+							sender.sendMessage(ChatColor.YELLOW + "[KitsuneChat] " + cmd.getHelpForSubcommand(sCmd));
+					}
+
 				}
 
 

--- a/src/main/java/net/cyberkitsune/prefixchat/KitsuneChatCommand.java
+++ b/src/main/java/net/cyberkitsune/prefixchat/KitsuneChatCommand.java
@@ -73,10 +73,10 @@ public class KitsuneChatCommand implements CommandExecutor, TabCompleter {
 
 				String subCommand = null;
 				String[] subCommandArgs = {};
-				if(args.length > 2)
+				if(args.length > 1)
 					subCommand = args[1];
 
-				if(args.length > 3)
+				if(args.length > 2)
 					subCommandArgs = Arrays.copyOfRange(args, 2, args.length);
 
 				if(cmd.requiresPlayer() && !(sender instanceof Player))

--- a/src/main/java/net/cyberkitsune/prefixchat/KitsuneChatCommand.java
+++ b/src/main/java/net/cyberkitsune/prefixchat/KitsuneChatCommand.java
@@ -125,7 +125,7 @@ public class KitsuneChatCommand implements CommandExecutor, TabCompleter {
 			{
 				sb.append(" (or: ");
 				sb.append(String.join(",", cmd.getAliases()));
-				sb.append(") ");
+				sb.append(")");
 			}
 			sb.append(" - ").append(cmd.getHelp());
 			target.sendMessage(sb.toString());

--- a/src/main/java/net/cyberkitsune/prefixchat/KitsuneChatCommand.java
+++ b/src/main/java/net/cyberkitsune/prefixchat/KitsuneChatCommand.java
@@ -123,11 +123,11 @@ public class KitsuneChatCommand implements CommandExecutor, TabCompleter {
 			sb.append("[KitsuneChat] /kc ").append(cmd.getName());
 			if(cmd.getAliases().size() > 0)
 			{
-				sb.append("(or: ");
+				sb.append(" (or: ");
 				sb.append(String.join(",", cmd.getAliases()));
 				sb.append(") ");
 			}
-			sb.append("- ").append(cmd.getHelp());
+			sb.append(" - ").append(cmd.getHelp());
 			target.sendMessage(sb.toString());
 		}
 	}

--- a/src/main/java/net/cyberkitsune/prefixchat/KitsuneChatCommand.java
+++ b/src/main/java/net/cyberkitsune/prefixchat/KitsuneChatCommand.java
@@ -98,7 +98,7 @@ public class KitsuneChatCommand implements CommandExecutor, TabCompleter {
 				{
 					sender.sendMessage(ChatColor.RED + String.format("[KitsuneChat] Invalid usage of /kc %s. Possible usages:", cmd.getName()));
 					for(String sCmd : cmd.getSubCommands())
-						sender.sendMessage(ChatColor.YELLOW + "[KitsuneChat]" + cmd.getHelpForSubcommand(sCmd));
+						sender.sendMessage(ChatColor.YELLOW + "[KitsuneChat] " + cmd.getHelpForSubcommand(sCmd));
 				}
 
 
@@ -164,11 +164,9 @@ public class KitsuneChatCommand implements CommandExecutor, TabCompleter {
 					{
 						KCommand cmd = commands.get(args[0]);
 						String subCommand = null;
-						String[] subCommandArgs = {};
 
-						if(args.length > 3)
+						if(args.length > 2)
 							subCommand = args[1];
-							subCommandArgs = Arrays.copyOfRange(args, 2, args.length);
 						if(cmd.senderCanRunCommand(commandSender, subCommand))
 						{
 							List<String> cmdCompletions = cmd.getPossibleCompletions(commandSender, subCommand);

--- a/src/main/java/net/cyberkitsune/prefixchat/command/ChannelCommand.java
+++ b/src/main/java/net/cyberkitsune/prefixchat/command/ChannelCommand.java
@@ -1,0 +1,74 @@
+package net.cyberkitsune.prefixchat.command;
+
+import net.cyberkitsune.prefixchat.KitsuneChat;
+import net.cyberkitsune.prefixchat.KitsuneChatUserData;
+import net.cyberkitsune.prefixchat.channels.KitsuneChannel;
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class ChannelCommand implements KCommand {
+    @Override
+    public String getName() {
+        return "channel";
+    }
+
+    @NotNull
+    @Override
+    public List<String> getAliases() {
+        return Collections.singletonList("ch");
+    }
+
+    @Override
+    public List<String> getSubCommands() {
+        return new ArrayList<String>(KitsuneChat.getInstance().channels.keySet());
+    }
+
+    @Override
+    public String getHelp() {
+        return "Changes your current default chat channel.";
+    }
+
+    @Override
+    public String getHelpForSubcommand(String subCommand) {
+        return String.format("/kc channel %s - Changes your chat channel to %s", subCommand,
+                KitsuneChat.getInstance().channels.get(subCommand).getChannelName());
+    }
+
+    @Override
+    public boolean requiresPlayer() {
+        return true;
+    }
+
+    @Override
+    public boolean runCommand(CommandSender sender, String subCommand, String[] args) {
+        if (subCommand == null)
+            return false;
+
+        if (!KitsuneChat.getInstance().channels.containsKey(subCommand))
+            return false;
+
+        KitsuneChannel ch = KitsuneChat.getInstance().channels.get(subCommand);
+        KitsuneChatUserData.getInstance().setUserChannel((Player) sender, ch.getPrefix());
+        sender.sendMessage(ChatColor.YELLOW + "[KitsuneChat] Default chat now set to " + ch.getChannelName());
+        return true;
+    }
+
+    @Override
+    public boolean hasPermission(Player p, String subCommand) {
+        if (subCommand != null)
+        {
+            if(KitsuneChat.getInstance().channels.containsKey(subCommand))
+            {
+                KitsuneChannel ch = KitsuneChat.getInstance().channels.get(subCommand);
+                return !p.hasPermission("kitsunechat.no." + ch.getChannelName());
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/net/cyberkitsune/prefixchat/command/ChannelCommand.java
+++ b/src/main/java/net/cyberkitsune/prefixchat/command/ChannelCommand.java
@@ -21,7 +21,7 @@ public class ChannelCommand implements KCommand {
     @NotNull
     @Override
     public List<String> getAliases() {
-        return Collections.singletonList("ch");
+        return Collections.singletonList("c");
     }
 
     @Override

--- a/src/main/java/net/cyberkitsune/prefixchat/command/ChannelCommand.java
+++ b/src/main/java/net/cyberkitsune/prefixchat/command/ChannelCommand.java
@@ -26,7 +26,7 @@ public class ChannelCommand implements KCommand {
 
     @Override
     public List<String> getSubCommands() {
-        return new ArrayList<String>(KitsuneChat.getInstance().channels.keySet());
+        return new ArrayList<>(KitsuneChat.getInstance().channels.keySet());
     }
 
     @Override
@@ -66,7 +66,7 @@ public class ChannelCommand implements KCommand {
             if(KitsuneChat.getInstance().channels.containsKey(subCommand))
             {
                 KitsuneChannel ch = KitsuneChat.getInstance().channels.get(subCommand);
-                return !p.hasPermission("kitsunechat.no." + ch.getChannelName());
+                return ch.hasPermission(p);
             }
         }
         return true;

--- a/src/main/java/net/cyberkitsune/prefixchat/command/KCommand.java
+++ b/src/main/java/net/cyberkitsune/prefixchat/command/KCommand.java
@@ -1,0 +1,62 @@
+package net.cyberkitsune.prefixchat.command;
+
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+
+import java.util.Collections;
+import java.util.List;
+
+public interface KCommand {
+    String getName();
+    default @NotNull List<String> getAliases()
+    {
+        return Collections.emptyList();
+    }
+    default List<String> getSubCommands()
+    {
+        return null;
+    }
+    default String getHelp()
+    {
+        return "";
+    }
+    default String getHelpForSubcommand(String subCommand)
+    {
+        return "";
+    }
+    boolean requiresPlayer();
+    boolean runCommand(CommandSender sender, String subCommand, String[] subCommandArgs);
+    default List<String> getPossibleCompletions(CommandSender sender, String subCommand)
+    {
+        if(getSubCommands() != null)
+        {
+            if (subCommand == null)
+                return getSubCommands();
+            else
+                return Collections.emptyList();
+        }
+
+        return null;
+    }
+
+    default boolean hasPermission(Player p, String subCommand)
+    {
+        if(subCommand != null)
+            return p.hasPermission("kitsunechat.command."+getName()+"."+subCommand);
+        return p.hasPermission("kitsunechat.command." + getName());
+    }
+
+    default boolean senderCanRunCommand(CommandSender s, String subCommand)
+    {
+        boolean canRun = true;
+        if(requiresPlayer() && !(s instanceof Player))
+            canRun = false;
+
+        if(s instanceof Player && !hasPermission((Player) s, subCommand))
+            canRun = false;
+
+        return canRun;
+    }
+}

--- a/src/main/java/net/cyberkitsune/prefixchat/command/KCommand.java
+++ b/src/main/java/net/cyberkitsune/prefixchat/command/KCommand.java
@@ -5,6 +5,7 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -33,7 +34,17 @@ public interface KCommand {
         if(getSubCommands() != null)
         {
             if (subCommand == null)
-                return getSubCommands();
+            {
+                ArrayList<String> validSubcommands = new ArrayList<>();
+                for(String sc : getSubCommands())
+                {
+                    if(!senderCanRunCommand(sender, sc))
+                        continue;
+
+                    validSubcommands.add(sc);
+                }
+                return validSubcommands;
+            }
             else
                 return Collections.emptyList();
         }

--- a/src/main/java/net/cyberkitsune/prefixchat/command/PartyCommand.java
+++ b/src/main/java/net/cyberkitsune/prefixchat/command/PartyCommand.java
@@ -9,6 +9,7 @@ import net.md_5.bungee.api.chat.HoverEvent;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -19,6 +20,11 @@ public class PartyCommand implements KCommand {
     @Override
     public String getName() {
         return "party";
+    }
+
+    @Override
+    public @NotNull List<String> getAliases() {
+        return Collections.singletonList("p");
     }
 
     @Override

--- a/src/main/java/net/cyberkitsune/prefixchat/command/PartyCommand.java
+++ b/src/main/java/net/cyberkitsune/prefixchat/command/PartyCommand.java
@@ -1,0 +1,140 @@
+package net.cyberkitsune.prefixchat.command;
+
+import net.cyberkitsune.prefixchat.ChatParties;
+import net.cyberkitsune.prefixchat.KitsuneChat;
+import net.cyberkitsune.prefixchat.KitsuneChatUserData;
+import net.md_5.bungee.api.chat.ClickEvent;
+import net.md_5.bungee.api.chat.ComponentBuilder;
+import net.md_5.bungee.api.chat.HoverEvent;
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+public class PartyCommand implements KCommand {
+    @Override
+    public String getName() {
+        return "party";
+    }
+
+    @Override
+    public List<String> getSubCommands() {
+        return Arrays.asList("join", "leave", "invite", "list");
+    }
+
+    @Override
+    public String getHelp() {
+        return "Allows you to create, join, leave, or invite people to a chat party.";
+    }
+
+    @Override
+    public String getHelpForSubcommand(String subCommand) {
+        switch (subCommand)
+        {
+            case "join":
+                return "/kc party join <name> - Joins a chat party by name.";
+            case "leave":
+                return "/kc party leave - Leaves a chat party";
+            case "invite":
+                return "/kc party invite <name> - Invites a user to join your chat party.";
+            case "list":
+                return "/kc party list - Shows who is in your current chat party.";
+            default:
+                return "";
+        }
+    }
+
+    @Override
+    public boolean requiresPlayer() {
+        return true;
+    }
+
+    @Override
+    public boolean runCommand(CommandSender sender, String command, String[] args) {
+        if (command == null)
+            return false;
+
+        switch (command)
+        {
+            case "join":
+                if (args != null && args.length > 1)
+                {
+                    ChatParties.getInstance().changeParty((Player) sender, args[0].toLowerCase());
+                    KitsuneChatUserData.getInstance().setUserChannel((Player) sender, KitsuneChat.getInstance().getConfig().getString("channels.party.prefix"));
+                    sender.sendMessage(ChatColor.YELLOW + "[KitsuneChat] You have joined the party " + args[0].toLowerCase() + "!");
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            case "leave":
+                ChatParties.getInstance().leaveParty((Player) sender, false);
+                return true;
+            case "invite":
+                if (args != null)
+                {
+                    if (ChatParties.getInstance().isInAParty((Player) sender)) {
+                        Player target = KitsuneChat.getInstance().getServer().getPlayer(args[0]);
+                        if (target != null) {
+                            ComponentBuilder cb = new ComponentBuilder("[KitsuneChat] ").
+                                    color(net.md_5.bungee.api.ChatColor.YELLOW).append(sender.getName())
+                                    .color(net.md_5.bungee.api.ChatColor.YELLOW).append(" has invited you to a party! Click here to join: ")
+                                    .color(net.md_5.bungee.api.ChatColor.YELLOW).append("[ACCEPT]")
+                                    .color(net.md_5.bungee.api.ChatColor.GREEN).bold(true).event(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/kc party join " + ChatParties.getInstance().getPartyName((Player) sender)))
+                                    .event(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new ComponentBuilder("Click to join " + ChatParties.getInstance().getPartyName((Player) sender)).create()));
+                            target.spigot().sendMessage(cb.create());
+                            ChatParties.getInstance().notifyParty(ChatParties.getInstance().getPartyName((Player) sender), ChatColor.GREEN + "[KitsuneChat] " + sender.getName() + " invited " + target.getDisplayName() + ChatColor.GREEN + " to the party.");
+                        } else {
+                            sender.sendMessage(ChatColor.RED + "[KitsuneChat] That player does not exist!");
+                        }
+                    } else {
+                        sender.sendMessage(ChatColor.RED + "[KitsuneChat] You aren't in a party!");
+                    }
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            case "list":
+                if (ChatParties.getInstance().isInAParty((Player) sender)) {
+                    StringBuilder playerlist = new StringBuilder();
+                    Set<Player> partyMembers = ChatParties.getInstance().getPartyMembers(ChatParties.getInstance().getPartyName((Player) sender));
+                    for (Player plr : partyMembers) {
+                        playerlist.append(plr.getDisplayName()).append(", ");
+                    }
+                    playerlist = new StringBuilder(playerlist.substring(0, playerlist.length() - 2) + ".");
+                    sender.sendMessage(ChatColor.YELLOW + "[KitsuneChat] " + partyMembers.size() + ((partyMembers.size() == 1) ? " person " : " people ") + "in the party.");
+                    sender.sendMessage(ChatColor.YELLOW + "[KitsuneChat] They are: " + playerlist + ".");
+                } else {
+                    sender.sendMessage(ChatColor.RED + "[KitsuneChat] You are not in a party!");
+                }
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    @Override
+    public List<String> getPossibleCompletions(CommandSender sender, String subcommand) {
+        if (subcommand != null)
+        {
+            switch (subcommand)
+            {
+                case "join":
+                    return Collections.singletonList("<party>");
+                case "leave":
+                case "list":
+                    return Collections.emptyList();
+                case "invite":
+                    return null;
+            }
+        }
+        return KCommand.super.getPossibleCompletions(sender, subcommand);
+    }
+}

--- a/src/main/java/net/cyberkitsune/prefixchat/command/PartyCommand.java
+++ b/src/main/java/net/cyberkitsune/prefixchat/command/PartyCommand.java
@@ -67,7 +67,7 @@ public class PartyCommand implements KCommand {
         switch (command)
         {
             case "join":
-                if (args != null && args.length > 1)
+                if (args != null && args.length > 0)
                 {
                     ChatParties.getInstance().changeParty((Player) sender, args[0].toLowerCase());
                     KitsuneChatUserData.getInstance().setUserChannel((Player) sender, KitsuneChat.getInstance().getConfig().getString("channels.party.prefix"));
@@ -82,7 +82,7 @@ public class PartyCommand implements KCommand {
                 ChatParties.getInstance().leaveParty((Player) sender, false);
                 return true;
             case "invite":
-                if (args != null)
+                if (args != null && args.length > 0)
                 {
                     if (ChatParties.getInstance().isInAParty((Player) sender)) {
                         Player target = KitsuneChat.getInstance().getServer().getPlayer(args[0]);

--- a/src/main/java/net/cyberkitsune/prefixchat/command/ReloadCommand.java
+++ b/src/main/java/net/cyberkitsune/prefixchat/command/ReloadCommand.java
@@ -1,0 +1,38 @@
+package net.cyberkitsune.prefixchat.command;
+
+import net.cyberkitsune.prefixchat.KitsuneChat;
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class ReloadCommand implements KCommand {
+    @Override
+    public String getName() {
+        return "reload";
+    }
+
+    @Override
+    public String getHelp() {
+        return "Reloads the plugin";
+    }
+
+    @Override
+    public boolean requiresPlayer() {
+        return false;
+    }
+
+    @Override
+    public boolean runCommand(CommandSender sender, String command, String[] args) {
+        KitsuneChat.getInstance().reload();
+        sender.sendMessage(ChatColor.GRAY + "[KitsuneChat] KitsuneChat reloaded! >w<");
+        return true;
+    }
+
+    @Override
+    public List<String> getPossibleCompletions(CommandSender sender, String subCommand) {
+        return Collections.emptyList();
+    }
+}


### PR DESCRIPTION
Created a new interface called `KCommand` and moved all `/kc` subcommands to it.

`/me`, `/msg`, and `/r` aren't done this way (yet?) and I'm unsure how to deal with those yet.