### PR TITLE
Support nicknames in PMs

### DIFF
--- a/src/main/java/net/cyberkitsune/prefixchat/KitsuneChatUtils.java
+++ b/src/main/java/net/cyberkitsune/prefixchat/KitsuneChatUtils.java
@@ -75,4 +75,16 @@ public class KitsuneChatUtils {
 				event.getMessage()
 				);
 	}
+
+	public Player getPlayerFromDisplay(String displayName)
+	{
+		Player out = null;
+		for(Player p : KitsuneChat.getInstance().getServer().getOnlinePlayers())
+		{
+			if(ChatColor.stripColor(p.getDisplayName()).equalsIgnoreCase(displayName))
+				out = p;
+		}
+
+		return out;
+	}
 }

--- a/src/main/java/net/cyberkitsune/prefixchat/UserMessaging.java
+++ b/src/main/java/net/cyberkitsune/prefixchat/UserMessaging.java
@@ -13,6 +13,7 @@ import com.google.common.base.Joiner;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.util.StringUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -235,10 +236,13 @@ public class UserMessaging implements CommandExecutor, Listener, TabCompleter {
 			if(args.length < 2)
 			{
 				ArrayList<String> names = new ArrayList<>();
+				ArrayList<String> completions = new ArrayList<>();
 				for(Player p : KitsuneChat.getInstance().getServer().getOnlinePlayers())
 					names.add(ChatColor.stripColor(p.getDisplayName()));
 
-				return names;
+				StringUtil.copyPartialMatches(args[args.length - 1], names, completions);
+
+				return completions;
 			}
 			else
 			{

--- a/src/main/java/net/cyberkitsune/prefixchat/UserMessaging.java
+++ b/src/main/java/net/cyberkitsune/prefixchat/UserMessaging.java
@@ -140,7 +140,7 @@ public class UserMessaging implements CommandExecutor, Listener, TabCompleter {
 				player = "CONSOLE";
 				locale = "en_US";
 			} else {
-				player = ((Player) sender).getName();
+				player = ChatColor.stripColor(((Player) sender).getDisplayName());
 				locale = ((Player) sender).getLocale();
 			}
 			
@@ -194,14 +194,14 @@ public class UserMessaging implements CommandExecutor, Listener, TabCompleter {
 				
 			// Get the target if not console
 			} else {
-				target = KitsuneChat.getInstance().getServer().getPlayer(otherPlayer);
+				target = KitsuneChatUtils.getInstance().getPlayerFromDisplay(otherPlayer);
 				
 				// Does the player exist/online?
 				if((target == null || !target.isOnline())) {
 					sender.sendMessage(String.format(LocalizedString.get("cantfind", locale), args[0]));
 					return false;
 				} else {
-					otherPlayer = target.getName(); // Get proper-cased name
+					otherPlayer = target.getDisplayName(); // Get proper-cased name
 				}
 			}
 						
@@ -234,7 +234,11 @@ public class UserMessaging implements CommandExecutor, Listener, TabCompleter {
 		{
 			if(args.length < 2)
 			{
-				return null;
+				ArrayList<String> names = new ArrayList<>();
+				for(Player p : KitsuneChat.getInstance().getServer().getOnlinePlayers())
+					names.add(ChatColor.stripColor(p.getDisplayName()));
+
+				return names;
 			}
 			else
 			{

--- a/src/main/java/net/cyberkitsune/prefixchat/UserMessaging.java
+++ b/src/main/java/net/cyberkitsune/prefixchat/UserMessaging.java
@@ -202,7 +202,7 @@ public class UserMessaging implements CommandExecutor, Listener, TabCompleter {
 					sender.sendMessage(String.format(LocalizedString.get("cantfind", locale), args[0]));
 					return false;
 				} else {
-					otherPlayer = target.getDisplayName(); // Get proper-cased name
+					otherPlayer = ChatColor.stripColor(target.getDisplayName()); // Get proper-cased name
 				}
 			}
 						


### PR DESCRIPTION
This PR switches PMs to using display names (color stripped) instead of player names.

On servers with nicknames this works correctly.

May have unintended consequences on some more weird plugin setups? (Make this configurable?)